### PR TITLE
Skip lock on read-only property to reduce an initialization race stall

### DIFF
--- a/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
+++ b/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
@@ -1561,13 +1561,11 @@ static NSURL *_sharedTrashURL;
 
 - (BOOL)isTTLCache
 {
-    BOOL isTTLCache;
-    
-    [self lock];
-        isTTLCache = _ttlCache;
-    [self unlock];
-  
-    return isTTLCache;
+    // Mutating ttlCache is deprecated, skip the lock
+    // Avoids pause lock when PINRemoteImageManager init creates disk cache
+    // and the initial background disk scan blocks the initialization thread
+    // from checking this property.
+    return _ttlCache;
 }
 
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
Mutating the TTL state of the cache is deprecated, so there's no need to apply the lock and expose ourselves to the case where the initial disk scan holds the lock while the remote image manager sets up.